### PR TITLE
Windows build fixups

### DIFF
--- a/src/launcher/gui/OFSGuiText.cpp
+++ b/src/launcher/gui/OFSGuiText.cpp
@@ -49,9 +49,7 @@ OFSGuiText::OFSGuiText(SDL_Renderer *renderer, const std::string &text,
 	_src.x = 0;
 	_src.y = 0;
 
-#ifndef _WIN32
-	SDL_FreeSurface(textureSurface); //WTF crashes on windows????
-#endif
+	SDL_FreeSurface(textureSurface);
 }
 
 OFSGuiText::~OFSGuiText() {

--- a/src/launcher/net/OFSNet.cpp
+++ b/src/launcher/net/OFSNet.cpp
@@ -39,7 +39,7 @@ void OFSNet::downloadFile(const std::string &path, const fs::path& to) {
 		fs::create_directories(dir);
 	}
 
-	FILE *file = std::fopen(to.c_str(), "wb");
+	FILE *file = std::fopen(to.string().c_str(), "wb");
 	if(!file) {
 		std::perror("FOPEN: ");
 	}


### PR DESCRIPTION
MSVC is missing an implicit cast for std::filesystem::path::value_type even though it should??
All other compilers are ok with this.

Removed ifdef -- it seems to be stable on Windows 