### PR TITLE
If there isn't a sourcemods dir, create one

### DIFF
--- a/src/shared/steam/OFSPathDiscover.cpp
+++ b/src/shared/steam/OFSPathDiscover.cpp
@@ -73,6 +73,10 @@ void OFSPathDiscover::expandPaths() {
 		if(fs::exists(p_steamPath / "steamapps/sourcemods")) {
 			std::cout << "Path also contains sourcemods dir" << std::endl;
 			p_sourcemodsPath = p_steamPath / "steamapps/sourcemods";
+		} else {
+			std::cout << "Path does not contain sourcemods dir, creating it..." << std::endl;
+			p_sourcemodsPath = p_steamPath / "steamapps/sourcemods";
+			fs::create_directory(p_steamPath / "steamapps/sourcemods");
 		}
 
 		if(fs::exists(p_steamPath /


### PR DESCRIPTION
Without this little check I think the path would resolve to "" + "/open_fortress" if the user never installed any sourcemods before.
which... might be bad 🙃 

on windows it resulted in the folder being created on the root of the drive the launcher was ran from.